### PR TITLE
Add `-d` flag for allowing tmux-tail-f persist on detach

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ kill the tmux session.  Uses the `-F` option instead of `-f`,
 which keeps trying to open a file if it is inaccessible.
 
 Optional arguments:
+  -d     do not kill tmux session upon detach.
   -v     use the 'even-vertical' layout (default).
   -h     use the 'even-horizontal' layout.
   -t     use the 'tiled' layout.

--- a/tmux-tail-f
+++ b/tmux-tail-f
@@ -4,9 +4,11 @@ TMUX=$(type -p tmux) || { echo "This script requires tmux"; exit 1; }
 
 SESSION="$TMUX-tail-f-$$"
 
+NOKILL=0
 LAYOUT=even-vertical
-while getopts ":UHvht" opt; do
+while getopts ":UHvhtd" opt; do
 	case $opt in
+        d) NOKILL=1;;
     	v) LAYOUT=even-vertical;;
 		h) LAYOUT=even-horizontal;;
 		t) LAYOUT=tiled;;
@@ -23,6 +25,7 @@ kill the tmux session. Uses the `-F` option instead of `-f`,
 which keeps trying to open a file if it is inaccessible.
 
 Optional arguments:
+  -d     do not kill tmux session upon detach.
   -v     use the 'even-vertical' layout (default).
   -h     use the 'even-horizontal' layout.
   -t     use the 'tiled' layout.
@@ -40,7 +43,7 @@ shift $(( OPTIND - 1 ))
 function at_exit() {
 	$TMUX kill-session -t "$SESSION" >/dev/null 2>&1
 }
-trap at_exit EXIT
+[[ "$NOKILL" == "1" ]] || trap at_exit EXIT
 
 $TMUX -q new-session -d -s "$SESSION"
 for FILE in "$@"; do


### PR DESCRIPTION
I typically run tmux-tail-f on remotes, and on a flaky SSH session,
tmux-tail-f kills itself (potentially losing any other shells or
programs attached,) hence needing to restart the tmux-tail-f session
again.

This change adds a flag that prevents trapping EXIT so that the tmux
session truly persists.  Stopping tails with Control-C should still
work, but tmux will not kill itself if there are other shells/programs
running on the session.